### PR TITLE
Feature/ephemeral-mongo: Upgrade from 'Mongo2Go' to 'EphemeralMongo7' for GitHub CI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   <ItemGroup>
     <PackageVersion Include="AutoMoqCore" Version="2.1.0" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+    <PackageVersion Include="EphemeralMongo7" Version="1.1.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageVersion Include="MongoDB.Driver" Version="2.24.0" />
-    <PackageVersion Include="Mongo2Go" Version="3.1.3" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>

--- a/src/CSharp.Mongo.Migration.Test/CSharp.Mongo.Migration.Test.csproj
+++ b/src/CSharp.Mongo.Migration.Test/CSharp.Mongo.Migration.Test.csproj
@@ -12,8 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMoqCore" />
+    <PackageReference Include="EphemeralMongo7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Mongo2Go" />
+    <PackageReference Include="MongoDB.Driver" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CSharp.Mongo.Migration.Test/Core/MigrationRunnerTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/MigrationRunnerTests.cs
@@ -4,11 +4,12 @@ using CSharp.Mongo.Migration.Interfaces;
 using CSharp.Mongo.Migration.Models;
 using CSharp.Mongo.Migration.Test.Infrastructure;
 
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace CSharp.Mongo.Migration.Test.Core;
 
-public class MigrationRunnerTests : DatabaseTest {
+public class MigrationRunnerTests : DatabaseTest, IDisposable {
     private readonly IMongoCollection<MigrationDocument> _migrationCollection;
     private readonly MigrationRunner _sut;
 
@@ -210,5 +211,10 @@ public class MigrationRunnerTests : DatabaseTest {
         var migrationDocuments = await _migrationCollection.Find(_ => true).ToListAsync();
 
         Assert.Empty(migrationDocuments);
+    }
+
+    public void Dispose() {
+        _migrationCollection.DeleteMany(_ => true);
+        _fixture.Database.GetCollection<BsonDocument>("Documents").DeleteMany(_ => true);
     }
 }

--- a/src/CSharp.Mongo.Migration.Test/Infrastructure/DatabaseTestFixture.cs
+++ b/src/CSharp.Mongo.Migration.Test/Infrastructure/DatabaseTestFixture.cs
@@ -1,24 +1,24 @@
 ﻿using CSharp.Mongo.Migration.Infrastructure;
 
-using Mongo2Go;
+using EphemeralMongo;
 
 using MongoDB.Driver;
 
 namespace CSharp.Mongo.Migration.Test.Infrastructure;
 
 public class DatabaseTestFixture : IDisposable {
-    private readonly MongoDbRunner _mongoDbRunner;
+    private readonly IMongoRunner _mongoDbRunner;
 
     public IMongoDatabase Database { get; set; }
     public string ConnectionString { get; private set; }
 
     public DatabaseTestFixture() {
-        _mongoDbRunner = MongoDbRunner.Start();
-        ConnectionString = $"{_mongoDbRunner.ConnectionString}_test";
+        _mongoDbRunner = MongoRunner.Run();
+        ConnectionString = $"{_mongoDbRunner.ConnectionString}/test";
         Database = DatabaseConnectionFactory.GetDatabase(ConnectionString);
     }
 
     public void Dispose() {
-        _mongoDbRunner?.Dispose();
+        _mongoDbRunner.Dispose();
     }
 }

--- a/src/CSharp.Mongo.Migration/CSharp.Mongo.Migration.csproj
+++ b/src/CSharp.Mongo.Migration/CSharp.Mongo.Migration.csproj
@@ -18,6 +18,7 @@
     <RepositoryUrl>https://github.com/JordanDChappell/CSharp.Mongo.Migration</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,6 +30,10 @@
     <Folder Include="Infrastructure\" />
     <Folder Include="Interfaces\" />
     <Folder Include="Models\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
'Mongo2Go' does not play nicely with GitHub workflow runners, while 'EphemeralMongo7' does.