### PR TITLE
5: Add name based assembly migration loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ MigrationRunner runner = new("yourDatabaseConnectionString");
 
 ```csharp
 await runner
-    .RegisterLocator(new AssemblyMigrationLocator("Assembly.With.Your.Migrations"))
+    .RegisterLocator(new AssemblyMigrationLocator("Assembly.With.Your.Migrations.dll"))
     .RunAsync();
 ```
 
@@ -54,7 +54,7 @@ To revert or restore a migration run the `RevertAsync("version")` function on an
 ```csharp
 MigrationRunner runner = new("youDatabaseConnectionString");
 await runner
-    .RegisterLocator(new AssemblyMigrationLocator("Assembly.With.Migration.Version"))
+    .RegisterLocator(new AssemblyMigrationLocator("Assembly.With.Migration.Version.dll"))
     .RevertAsync("version");
 ```
 

--- a/src/CSharp.Mongo.Migration.Test/Core/Locators/AssemblyMigrationLocatorTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/Locators/AssemblyMigrationLocatorTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+
+using CSharp.Mongo.Migration.Core.Locators;
+using CSharp.Mongo.Migration.Interfaces;
+using CSharp.Mongo.Migration.Models;
+using CSharp.Mongo.Migration.Test.Infrastructure;
+
+using MongoDB.Driver;
+
+namespace CSharp.Mongo.Migration.Test.Core.Locators;
+
+public class AssemblyMigrationLocatorTests : DatabaseTest, IDisposable {
+    private readonly IMongoCollection<MigrationDocument> _migrationCollection;
+
+    public AssemblyMigrationLocatorTests(DatabaseTestFixture fixture) : base(fixture) {
+        _migrationCollection = fixture.Database.GetCollection<MigrationDocument>("_migrations");
+    }
+
+    [Fact]
+    public void GetMigrations_GivenAssemblyAndNoMigrationsInDatabase_ShouldReturnAllMigrations() {
+        AssemblyMigrationLocator sut = new(Assembly.GetExecutingAssembly());
+
+        IEnumerable<IMigration> result = sut.GetAvailableMigrations(_migrationCollection);
+
+        Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    public void GetMigrations_GivenAssemblyNameAndNoMigrationsInDatabase_ShouldReturnAllMigrations() {
+        AssemblyMigrationLocator sut = new("CSharp.Mongo.Migration.Test.dll");
+
+        IEnumerable<IMigration> result = sut.GetAvailableMigrations(_migrationCollection);
+
+        Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    public void GetMigrations_GivenAssemblyAndMigrationsInDatabase_ShouldReturnUnappliedMigrations() {
+        List<IMigration> migrations = new() {
+            new TestMigration1(),
+            new TestMigration2(),
+            new TestMigration3(),
+        };
+
+        _migrationCollection.InsertOne(new() {
+            Name = migrations.First().Name,
+            Version = migrations.First().Version,
+        });
+
+        AssemblyMigrationLocator sut = new(Assembly.GetExecutingAssembly());
+
+        IEnumerable<IMigration> result = sut.GetAvailableMigrations(_migrationCollection);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    public void Dispose() {
+        _migrationCollection.DeleteMany(_ => true);
+    }
+}

--- a/src/CSharp.Mongo.Migration.Test/Core/Locators/ProvidedMigrationLocatorTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/Locators/ProvidedMigrationLocatorTests.cs
@@ -7,10 +7,10 @@ using MongoDB.Driver;
 
 namespace CSharp.Mongo.Migration.Test.Core.Locators;
 
-public class SimpleMigrationLocatorTests : DatabaseTest, IDisposable {
+public class ProvidedMigrationLocatorTests : DatabaseTest, IDisposable {
     private readonly IMongoCollection<MigrationDocument> _migrationCollection;
 
-    public SimpleMigrationLocatorTests(DatabaseTestFixture fixture) : base(fixture) {
+    public ProvidedMigrationLocatorTests(DatabaseTestFixture fixture) : base(fixture) {
         _migrationCollection = fixture.Database.GetCollection<MigrationDocument>("_migrations");
     }
 

--- a/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
+++ b/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
@@ -18,6 +18,10 @@ public class AssemblyMigrationLocator : IMigrationLocator {
         _assembly = assembly;
     }
 
+    public AssemblyMigrationLocator(string assemblyFile) {
+        _assembly = Assembly.LoadFrom(assemblyFile);
+    }
+
     public IEnumerable<IMigration> GetAvailableMigrations(IMongoCollection<MigrationDocument> collection) {
         IEnumerable<MigrationDocument> documents = collection.Find(_ => true).ToList();
         return GetMigrationsFromAssembly().Where(m => !documents.Any(d => d.Version == m.Version));

--- a/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
+++ b/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
@@ -5,7 +5,7 @@ using CSharp.Mongo.Migration.Models;
 
 using MongoDB.Driver;
 
-namespace CSharp.Mongo.Migration;
+namespace CSharp.Mongo.Migration.Core.Locators;
 
 /// <summary>
 /// Locate all concrete classes that implement the `IMigration` interface in an assembly.


### PR DESCRIPTION
## Description
Simplify assembly loading by adding a new constructor to the `AssemblyMigrationLocator` that accepts a dll name

## Changes
- Implement new constructor
- Add unit tests
- Update readme syntax