### PR TITLE
devops(cd): use release name as tag / version name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: cd
 
 on:
   release:
-    types: [published]
+    types: [published]  
 
 jobs:
   cd:
@@ -21,8 +21,8 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
       - name: Build
-        run: dotnet build --configuration $configuration /p:Version=${{vars.VERSION}} $projectPath
+        run: dotnet build --configuration $configuration /p:Version=${{github.event.release.name}} $projectPath
       - name: Pack
-        run: dotnet pack --configuration $configuration --no-build /p:PackageVersion=${{vars.VERSION}} $projectPath --output .
+        run: dotnet pack --configuration $configuration --no-build /p:PackageVersion=${{github.event.release.name}} $projectPath --output .
       - name: Push
         run: dotnet nuget push "*.nupkg" --api-key ${{secrets.NUGET_KEY}} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Description
Simplify release process by using triggered release name as the version when publishing a package.

## Changes
- Replace `{{vars.VERSION}}` with `{{github.event.release.name}}`