### PR TITLE
Feature/8: Implement optional migration dependency / ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ An optional `bool Skip()` method can be defined that can be used to conditionall
 
 `DownAsync` will be called when the `MigrationRunner.RevertAsync(string)` method is called, if you don't expect to revert a migration, simply have this method throw an exception.
 
+### Explicit Order
+
+If a migration requires or depends on another migration script, the `IOrderedMigration` interface can be used and it's `DependsOn` property implemented to provide a version dependencies between migrations.
+
+**Note:** Circular dependency / valid graph checks are not implemented in the library at this time, be careful defining depencies to avoid issues.
+
 ## Restoring Migrations
 
 To revert or restore a migration run the `RevertAsync("version")` function on an instance of the `MigrationRunner` class

--- a/src/CSharp.Mongo.Migration.Test/Core/Locators/AssemblyMigrationLocatorTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/Locators/AssemblyMigrationLocatorTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using CSharp.Mongo.Migration.Core.Locators;
 using CSharp.Mongo.Migration.Interfaces;
 using CSharp.Mongo.Migration.Models;
+using CSharp.Mongo.Migration.Test.Data;
 using CSharp.Mongo.Migration.Test.Infrastructure;
 
 using MongoDB.Driver;
@@ -22,7 +23,7 @@ public class AssemblyMigrationLocatorTests : DatabaseTest, IDisposable {
 
         IEnumerable<IMigration> result = sut.GetAvailableMigrations(_migrationCollection);
 
-        Assert.Equal(3, result.Count());
+        Assert.Equal(5, result.Count());
     }
 
     [Fact]
@@ -31,7 +32,7 @@ public class AssemblyMigrationLocatorTests : DatabaseTest, IDisposable {
 
         IEnumerable<IMigration> result = sut.GetAvailableMigrations(_migrationCollection);
 
-        Assert.Equal(3, result.Count());
+        Assert.Equal(5, result.Count());
     }
 
     [Fact]
@@ -51,7 +52,7 @@ public class AssemblyMigrationLocatorTests : DatabaseTest, IDisposable {
 
         IEnumerable<IMigration> result = sut.GetAvailableMigrations(_migrationCollection);
 
-        Assert.Equal(2, result.Count());
+        Assert.Equal(4, result.Count());
     }
 
     public void Dispose() {

--- a/src/CSharp.Mongo.Migration.Test/Core/Locators/ProvidedMigrationLocatorTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/Locators/ProvidedMigrationLocatorTests.cs
@@ -1,6 +1,7 @@
 using CSharp.Mongo.Migration.Core.Locators;
 using CSharp.Mongo.Migration.Interfaces;
 using CSharp.Mongo.Migration.Models;
+using CSharp.Mongo.Migration.Test.Data;
 using CSharp.Mongo.Migration.Test.Infrastructure;
 
 using MongoDB.Driver;

--- a/src/CSharp.Mongo.Migration.Test/Core/MigrationRunnerTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/MigrationRunnerTests.cs
@@ -2,6 +2,7 @@
 using CSharp.Mongo.Migration.Core.Locators;
 using CSharp.Mongo.Migration.Interfaces;
 using CSharp.Mongo.Migration.Models;
+using CSharp.Mongo.Migration.Test.Data;
 using CSharp.Mongo.Migration.Test.Infrastructure;
 
 using MongoDB.Bson;

--- a/src/CSharp.Mongo.Migration.Test/Core/MigrationRunnerTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/MigrationRunnerTests.cs
@@ -1,4 +1,6 @@
-﻿using CSharp.Mongo.Migration.Core;
+﻿using System.Reflection;
+
+using CSharp.Mongo.Migration.Core;
 using CSharp.Mongo.Migration.Core.Locators;
 using CSharp.Mongo.Migration.Interfaces;
 using CSharp.Mongo.Migration.Models;
@@ -143,6 +145,21 @@ public class MigrationRunnerTests : DatabaseTest, IDisposable {
         Assert.Equal(2, migrations.Count);
         Assert.Equal(firstMigration.Version, migrations.First().Version);
         Assert.Equal(secondMigration.Version, migrations.Last().Version);
+    }
+
+    [Fact]
+    public async void RunAsync_GivenOrderedMigrations_ShouldRunAllMigrationsInOrder() {
+        var result = await _sut
+            .RegisterLocator(new AssemblyMigrationLocator(Assembly.GetExecutingAssembly()))
+            .RunAsync();
+
+        Assert.Equal(5, result.Steps.Count());
+        Assert.Equal("Migration 4", result.Steps.ElementAt(3).Name);
+        Assert.Equal("Migration 5", result.Steps.ElementAt(4).Name);
+
+        var migrations = await _migrationCollection.Find(_ => true).ToListAsync();
+
+        Assert.Equal(5, migrations.Count);
     }
 
     [Fact]

--- a/src/CSharp.Mongo.Migration.Test/Data/TestDocument.cs
+++ b/src/CSharp.Mongo.Migration.Test/Data/TestDocument.cs
@@ -1,6 +1,6 @@
 ﻿using MongoDB.Bson;
 
-namespace CSharp.Mongo.Migration.Test;
+namespace CSharp.Mongo.Migration.Test.Data;
 
 public class TestDocumentV1 {
     public ObjectId Id { get; set; }

--- a/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
+++ b/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
@@ -62,7 +62,7 @@ public class TestMigration3 : IMigration {
     }
 
     public Task UpAsync(IMongoDatabase database) {
-        throw new NotImplementedException();
+        return Task.CompletedTask;
     }
 }
 
@@ -78,7 +78,7 @@ public class TestMigration4 : IOrderedMigration {
     }
 
     public Task UpAsync(IMongoDatabase database) {
-        throw new NotImplementedException();
+        return Task.CompletedTask;
     }
 }
 
@@ -94,6 +94,6 @@ public class TestMigration5 : IOrderedMigration {
     }
 
     public Task UpAsync(IMongoDatabase database) {
-        throw new NotImplementedException();
+        return Task.CompletedTask;
     }
 }

--- a/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
+++ b/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
@@ -2,7 +2,7 @@
 
 using MongoDB.Driver;
 
-namespace CSharp.Mongo.Migration.Test;
+namespace CSharp.Mongo.Migration.Test.Data;
 
 public class TestMigration1 : IMigration {
     public string Name => "Migration 1";
@@ -56,6 +56,38 @@ public class TestMigration2 : IMigration {
 public class TestMigration3 : IMigration {
     public string Name => "Migration 3";
     public string Version => "1993.10.09 migration3";
+
+    public Task DownAsync(IMongoDatabase database) {
+        throw new NotImplementedException();
+    }
+
+    public Task UpAsync(IMongoDatabase database) {
+        throw new NotImplementedException();
+    }
+}
+
+public class TestMigration4 : IOrderedMigration {
+    public string Name => "Migration 4";
+    public string Version => "2024.01.01 migration4";
+    public IEnumerable<string> DependsOn => new List<string>() {
+        "1993.10.05 migration1"
+    };
+
+    public Task DownAsync(IMongoDatabase database) {
+        throw new NotImplementedException();
+    }
+
+    public Task UpAsync(IMongoDatabase database) {
+        throw new NotImplementedException();
+    }
+}
+
+public class TestMigration5 : IOrderedMigration {
+    public string Name => "Migration 5";
+    public string Version => "2024.02.01 migration5";
+    public IEnumerable<string> DependsOn => new List<string>() {
+        "2024.01.01 migration4"
+    };
 
     public Task DownAsync(IMongoDatabase database) {
         throw new NotImplementedException();

--- a/src/CSharp.Mongo.Migration.Test/Helpers/MigrationRunnerHelperTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Helpers/MigrationRunnerHelperTests.cs
@@ -1,0 +1,81 @@
+﻿using CSharp.Mongo.Migration.Interfaces;
+using CSharp.Mongo.Migration.Models;
+using CSharp.Mongo.Migration.Test.Data;
+
+namespace CSharp.Mongo.Migration.Test.Helpers;
+
+public class MigrationRunnerHelperTests {
+    [Fact]
+    public void FindMigrationsWhereDependenciesAreMet_GivenAllDependenciesMet_ShouldReturnAll() {
+        List<IOrderedMigration> orderedMigrations = new() {
+            new TestMigration4(),
+            new TestMigration5(),
+        };
+        List<MigrationDocument> migrationDocuments = new() {
+            new MigrationDocument() {
+                Version = "1993.10.05 migration1",
+            },
+            new MigrationDocument() {
+                Version = "2024.01.01 migration4",
+            },
+        };
+
+        var result = MigrationRunnerHelper.FindMigrationsWhereDependenciesAreMet(orderedMigrations, migrationDocuments);
+
+        Assert.Equal(orderedMigrations.Count, result.Count());
+    }
+
+    [Fact]
+    public void FindMigrationsWhereDependenciesAreMet_GivenNotAllDependenciesMet_ShouldReturnExpectedResult() {
+        List<IOrderedMigration> orderedMigrations = new() {
+            new TestMigration4(),
+            new TestMigration5(),
+        };
+        List<MigrationDocument> migrationDocuments = new() {
+            new MigrationDocument() {
+                Version = "1993.10.05 migration1",
+            },
+        };
+
+        var result = MigrationRunnerHelper.FindMigrationsWhereDependenciesAreMet(orderedMigrations, migrationDocuments);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void AnyMigrationsLeftToRun_GivenNotAllDocumentsExist_ShouldReturnTrue() {
+        List<IOrderedMigration> orderedMigrations = new() {
+            new TestMigration4(),
+            new TestMigration5(),
+        };
+        List<MigrationDocument> migrationDocuments = new() {
+            new MigrationDocument() {
+                Version = "2024.01.01 migration4",
+            },
+        };
+
+        var result = MigrationRunnerHelper.AnyMigrationsLeftToRun(orderedMigrations, migrationDocuments);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void AnyMigrationsLeftToRun_GivenAllDocumentsExist_ShouldReturnFalse() {
+        List<IOrderedMigration> orderedMigrations = new() {
+            new TestMigration4(),
+            new TestMigration5(),
+        };
+        List<MigrationDocument> migrationDocuments = new() {
+            new MigrationDocument() {
+                Version = "2024.01.01 migration4",
+            },
+            new MigrationDocument() {
+                Version = "2024.02.01 migration5",
+            },
+        };
+
+        var result = MigrationRunnerHelper.AnyMigrationsLeftToRun(orderedMigrations, migrationDocuments);
+
+        Assert.False(result);
+    }
+}

--- a/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
+++ b/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 
+using CSharp.Mongo.Migration.Helpers;
 using CSharp.Mongo.Migration.Interfaces;
 using CSharp.Mongo.Migration.Models;
 
@@ -23,8 +24,8 @@ public class AssemblyMigrationLocator : IMigrationLocator {
     }
 
     public IEnumerable<IMigration> GetAvailableMigrations(IMongoCollection<MigrationDocument> collection) {
-        IEnumerable<MigrationDocument> documents = collection.Find(_ => true).ToList();
-        return GetMigrationsFromAssembly().Where(m => !documents.Any(d => d.Version == m.Version));
+        IEnumerable<IMigration> migrations = GetMigrationsFromAssembly();
+        return MigrationLocatorHelper.FilterCompletedMigrations(collection, migrations);
     }
 
     public IMigration? GetMigration(string version) =>

--- a/src/CSharp.Mongo.Migration/Core/Locators/ProvidedMigrationLocator.cs
+++ b/src/CSharp.Mongo.Migration/Core/Locators/ProvidedMigrationLocator.cs
@@ -1,4 +1,5 @@
-﻿using CSharp.Mongo.Migration.Interfaces;
+﻿using CSharp.Mongo.Migration.Helpers;
+using CSharp.Mongo.Migration.Interfaces;
 using CSharp.Mongo.Migration.Models;
 
 using MongoDB.Driver;
@@ -15,10 +16,8 @@ public class ProvidedMigrationLocator : IMigrationLocator {
         _migrations = migrations;
     }
 
-    public IEnumerable<IMigration> GetAvailableMigrations(IMongoCollection<MigrationDocument> collection) {
-        IEnumerable<MigrationDocument> documents = collection.Find(_ => true).ToList();
-        return _migrations.Where(m => !documents.Any(d => d.Version == m.Version));
-    }
+    public IEnumerable<IMigration> GetAvailableMigrations(IMongoCollection<MigrationDocument> collection) =>
+        MigrationLocatorHelper.FilterCompletedMigrations(collection, _migrations);
 
     public IMigration? GetMigration(string version) => _migrations.FirstOrDefault(m => m.Version == version);
 }

--- a/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
+++ b/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
@@ -84,7 +84,7 @@ public class MigrationRunner : IMigrationRunner {
 
         // Separate regular from ordered migrations - run these in separate blocks
         IEnumerable<IOrderedMigration> orderedMigrations = migrations.OfType<IOrderedMigration>();
-        IEnumerable<IMigration> basicMigrations = migrations.Except(orderedMigrations);
+        IEnumerable<IMigration> basicMigrations = migrations.Where(m => m is not IOrderedMigration);
 
         foreach (IMigration migration in basicMigrations) {
             MigrationDocument document = await RunMigrationAsync(migration);
@@ -106,7 +106,7 @@ public class MigrationRunner : IMigrationRunner {
         do {
             List<MigrationDocument> migrationDocuments = await _migrationCollection.Find(_ => true).ToListAsync();
             IEnumerable<IOrderedMigration> migrationsToRun = MigrationRunnerHelper.FindMigrationsWhereDependenciesAreMet(
-                migrations,
+                migrations.Where(m => !steps.Any(s => s.Version == m.Version)),
                 migrationDocuments
             );
 

--- a/src/CSharp.Mongo.Migration/Helpers/MigrationLocatorHelper.cs
+++ b/src/CSharp.Mongo.Migration/Helpers/MigrationLocatorHelper.cs
@@ -1,0 +1,25 @@
+﻿using CSharp.Mongo.Migration.Interfaces;
+using CSharp.Mongo.Migration.Models;
+
+using MongoDB.Driver;
+
+namespace CSharp.Mongo.Migration.Helpers;
+
+/// <summary>
+/// Common helper methods used by `IMigrationLocator` instances.
+/// </summary>
+public static class MigrationLocatorHelper {
+    /// <summary>
+    /// Filter a collection of migrations to remove any that have already been recorded.
+    /// </summary>
+    /// <param name="collection">`MigrationDocument` database collection.</param>
+    /// <param name="migrations">Collection of `IMigration` instances.</param>
+    /// <returns>Filtered collection of `IMigration` instances.</returns>
+    public static IEnumerable<IMigration> FilterCompletedMigrations(
+        IMongoCollection<MigrationDocument> collection,
+        IEnumerable<IMigration> migrations
+    ) {
+        IEnumerable<MigrationDocument> documents = collection.Find(_ => true).ToList();
+        return migrations.Where(m => !documents.Any(d => d.Version == m.Version));
+    }
+}

--- a/src/CSharp.Mongo.Migration/Helpers/MigrationRunnerHelper.cs
+++ b/src/CSharp.Mongo.Migration/Helpers/MigrationRunnerHelper.cs
@@ -3,7 +3,16 @@ using CSharp.Mongo.Migration.Models;
 
 namespace CSharp.Mongo.Migration;
 
+/// <summary>
+/// Common helper methods used by the `MigrationRunner` class.
+/// </summary>
 public static class MigrationRunnerHelper {
+    /// <summary>
+    /// Find all migrations that can be run, where their dependencies have been recorded.
+    /// </summary>
+    /// <param name="migrations">Collection of `IOrderedMigration` instances.</param>
+    /// <param name="completedMigrations">Collection of recorded `MigrationDocument` instances.</param>
+    /// <returns>A collection of `IMigration` instances that can be run based on dependencies.</returns>
     public static IEnumerable<IOrderedMigration> FindMigrationsWhereDependenciesAreMet(
         IEnumerable<IOrderedMigration> migrations,
         IEnumerable<MigrationDocument> completedMigrations
@@ -12,6 +21,12 @@ public static class MigrationRunnerHelper {
         return migrations.Where(m => m.DependsOn.All(v => versions.Contains(v)));
     }
 
+    /// <summary>
+    /// Determine if there are any migrations in the collection that have not been recorded.
+    /// </summary>
+    /// <param name="migrations">Collection of `IOrderedMigration` instances.</param>
+    /// <param name="completedMigrations">Collection of recorded `MigrationDocument` instances.</param>
+    /// <returns>True if there are any migrations in the collection that have not been recorded, else false.</returns>
     public static bool AnyMigrationsLeftToRun(
         IEnumerable<IOrderedMigration> migrations,
         IEnumerable<MigrationDocument> completedMigrations

--- a/src/CSharp.Mongo.Migration/Helpers/MigrationRunnerHelper.cs
+++ b/src/CSharp.Mongo.Migration/Helpers/MigrationRunnerHelper.cs
@@ -1,0 +1,29 @@
+﻿using CSharp.Mongo.Migration.Interfaces;
+using CSharp.Mongo.Migration.Models;
+
+namespace CSharp.Mongo.Migration;
+
+public static class MigrationRunnerHelper {
+    public static IEnumerable<IOrderedMigration> FindMigrationsWhereDependenciesAreMet(
+        IEnumerable<IOrderedMigration> migrations,
+        IEnumerable<MigrationDocument> completedMigrations
+    ) {
+        List<string?> versions = GetDocumentVersions(completedMigrations);
+        return migrations.Where(m => m.DependsOn.All(v => versions.Contains(v)));
+    }
+
+    public static bool AnyMigrationsLeftToRun(
+        IEnumerable<IOrderedMigration> migrations,
+        IEnumerable<MigrationDocument> completedMigrations
+    ) {
+        List<string> expectedVersions = GetMigrationVersions(migrations);
+        List<string?> completedVersions = GetDocumentVersions(completedMigrations);
+        return expectedVersions.Except(completedVersions).Any();
+    }
+
+    private static List<string> GetMigrationVersions(IEnumerable<IMigration> migrations) =>
+        migrations.Select(m => m.Version).ToList();
+
+    private static List<string?> GetDocumentVersions(IEnumerable<MigrationDocument> documents) =>
+        documents.Select(m => m.Version).ToList();
+}

--- a/src/CSharp.Mongo.Migration/Interfaces/IOrderedMigration.cs
+++ b/src/CSharp.Mongo.Migration/Interfaces/IOrderedMigration.cs
@@ -1,0 +1,11 @@
+﻿namespace CSharp.Mongo.Migration.Interfaces;
+
+/// <summary>
+/// Ordered migration script contract, uses `IMigration` as it's base.
+/// </summary>
+public interface IOrderedMigration : IMigration {
+    /// <summary>
+    /// A collection of migration versions that the current migration script depends on.
+    /// </summary>
+    public IEnumerable<string> DependsOn { get; }
+}


### PR DESCRIPTION
## Description
This PR implements very rudimentary (and inefficient) ordering of migrations using a new `IOrderedMigration` interface.

## Changes
- Create new `IOrderedMigration` contract that extends the `IMigration` contract with a new property for dependent versions
- Update the `MigrationRunner` class to ensure migrations run in order if dependencies exist

## Testing
- New unit tests have been added for helper classes
- Integration style tests have been extended to cover explicit dependency cases