### PR TITLE
Feature/21: Add a constructor to set the `MigrationRunner.MigrationCollectionName` property + add a section about migration documents to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ await runner
     .RevertAsync("version");
 ```
 
+### Migration Documents
+
+When a migration has been applied a new document will be created in the target database in a collection named `_migrations` by default. These documents are used to track which migrations have been applied and when they were applied.
+
+**Note:** to override the default collection name, use a constructor that includes the `migrationCollectionName` parameter, or set the public `MigrationRunner.MigrationCollectionName` property.
+
 ## Why Create Another Library?
 
 There are a number of other libraries for MongoDB designed to be used in C#. This library was written out of necessity to be used in a large development team with fairly sizeable database instances. There are some use cases that this library caters to that others do not:

--- a/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
+++ b/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
@@ -22,10 +22,23 @@ public class MigrationRunner : IMigrationRunner {
         _migrationCollection = _database.GetCollection<MigrationDocument>(MigrationCollectionName);
     }
 
+    public MigrationRunner(string connectionString, string migrationCollectionName) {
+        _database = DatabaseConnectionFactory.GetDatabase(connectionString);
+        _migrationCollection = _database.GetCollection<MigrationDocument>(MigrationCollectionName);
+        MigrationCollectionName = migrationCollectionName;
+    }
+
     public MigrationRunner(string connectionString, IMigrationLocator migrationLocator) {
         _database = DatabaseConnectionFactory.GetDatabase(connectionString);
         _migrationCollection = _database.GetCollection<MigrationDocument>(MigrationCollectionName);
         _migrationLocator = migrationLocator;
+    }
+
+    public MigrationRunner(string connectionString, string migrationCollectionName, IMigrationLocator migrationLocator) {
+        _database = DatabaseConnectionFactory.GetDatabase(connectionString);
+        _migrationCollection = _database.GetCollection<MigrationDocument>(MigrationCollectionName);
+        _migrationLocator = migrationLocator;
+        MigrationCollectionName = migrationCollectionName;
     }
 
     public IMigrationRunner RegisterLocator(IMigrationLocator locator) {


### PR DESCRIPTION
## Description
Making the `MigrationCollectionName` property more accessible.

## Changes
- Add new constructors to the `MigrationRunner` to explicitly set the collection name for migration documents
- Update `README.md` to include a "Migration Documents" section