### PR TITLE
Hotfix/type-boxing-error: Use correct base interface when iterating migrations, not all migrations implement IAsyncMigration

### DIFF
--- a/src/CSharp.Mongo.Migration.Test/Core/Locators/AssemblyMigrationLocatorTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/Locators/AssemblyMigrationLocatorTests.cs
@@ -37,7 +37,7 @@ public class AssemblyMigrationLocatorTests : DatabaseTest, IDisposable {
 
     [Fact]
     public void GetMigrations_GivenAssemblyAndMigrationsInDatabase_ShouldReturnUnappliedMigrations() {
-        List<IAsyncMigration> migrations = new() {
+        List<IMigrationBase> migrations = new() {
             new TestMigration1(),
             new TestMigration2(),
             new TestMigration3(),

--- a/src/CSharp.Mongo.Migration.Test/Core/Locators/ProvidedMigrationLocatorTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/Locators/ProvidedMigrationLocatorTests.cs
@@ -17,7 +17,7 @@ public class ProvidedMigrationLocatorTests : DatabaseTest, IDisposable {
 
     [Fact]
     public void GetMigrations_GivenNoMigrationsInDatabase_ShouldReturnAllMigrations() {
-        List<IAsyncMigration> migrations = new() {
+        List<IMigrationBase> migrations = new() {
             new TestMigration1(),
             new TestMigration2(),
             new TestMigration3(),
@@ -32,7 +32,7 @@ public class ProvidedMigrationLocatorTests : DatabaseTest, IDisposable {
 
     [Fact]
     public void GetMigrations_GivenMigrationsInDatabase_ShouldReturnUnappliedMigrations() {
-        List<IAsyncMigration> migrations = new() {
+        List<IMigrationBase> migrations = new() {
             new TestMigration1(),
             new TestMigration2(),
             new TestMigration3(),

--- a/src/CSharp.Mongo.Migration.Test/Core/MigrationRunnerTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/MigrationRunnerTests.cs
@@ -55,9 +55,9 @@ public class MigrationRunnerTests : DatabaseTest, IDisposable {
         };
         await _fixture.Database.GetCollection<TestDocumentV1>("Documents").InsertManyAsync(documentsToMigrate);
 
-        IAsyncMigration migrationToRun = new TestMigration1();
+        IMigration migrationToRun = new TestMigration1();
         var result = await _sut
-            .RegisterLocator(new ProvidedMigrationLocator(new List<IAsyncMigration>() { migrationToRun }))
+            .RegisterLocator(new ProvidedMigrationLocator(new List<IMigrationBase>() { migrationToRun }))
             .RunAsync();
 
         Assert.Single(result.Steps);
@@ -87,14 +87,14 @@ public class MigrationRunnerTests : DatabaseTest, IDisposable {
         };
         await _fixture.Database.GetCollection<TestDocumentV2>("Documents").InsertManyAsync(documentsToMigrate);
 
-        IAsyncMigration migrationToRun = new TestMigration1();
+        IMigration migrationToRun = new TestMigration1();
         await _migrationCollection.InsertOneAsync(new() {
             Name = migrationToRun.Name,
             Version = migrationToRun.Version
         });
 
         var result = await _sut
-            .RegisterLocator(new ProvidedMigrationLocator(new List<IAsyncMigration>() { migrationToRun }))
+            .RegisterLocator(new ProvidedMigrationLocator(new List<IMigrationBase>() { migrationToRun }))
             .RunAsync();
 
         Assert.Empty(result.Steps);
@@ -118,7 +118,7 @@ public class MigrationRunnerTests : DatabaseTest, IDisposable {
         };
         await _fixture.Database.GetCollection<TestDocumentV2>("Documents").InsertManyAsync(documentsToMigrate);
 
-        IAsyncMigration firstMigration = new TestMigration1();
+        IMigration firstMigration = new TestMigration1();
         IAsyncMigration secondMigration = new TestMigration2();
         await _migrationCollection.InsertOneAsync(new() {
             Name = firstMigration.Name,
@@ -126,7 +126,7 @@ public class MigrationRunnerTests : DatabaseTest, IDisposable {
         });
 
         var result = await _sut
-            .RegisterLocator(new ProvidedMigrationLocator(new List<IAsyncMigration>() { firstMigration, secondMigration }))
+            .RegisterLocator(new ProvidedMigrationLocator(new List<IMigrationBase>() { firstMigration, secondMigration }))
             .RunAsync();
 
         Assert.Single(result.Steps);
@@ -177,7 +177,7 @@ public class MigrationRunnerTests : DatabaseTest, IDisposable {
 
     [Fact]
     public async Task RestoreAsync_GivenCannotFindDocument_ShouldThrowArgumentException() {
-        List<IAsyncMigration> migrations = new() { new TestMigration1() };
+        List<IMigrationBase> migrations = new() { new TestMigration1() };
         IMigrationLocator migrationLocator = new ProvidedMigrationLocator(migrations);
 
         var exception = await Assert.ThrowsAsync<ArgumentException>(
@@ -201,7 +201,7 @@ public class MigrationRunnerTests : DatabaseTest, IDisposable {
         await _fixture.Database.GetCollection<TestDocumentV2>("Documents").InsertManyAsync(documentsToRestore);
 
         // Prepare migration locator
-        List<IAsyncMigration> migrations = new() { new TestMigration1() };
+        List<IMigrationBase> migrations = new() { new TestMigration1() };
         IMigrationLocator migrationLocator = new ProvidedMigrationLocator(migrations);
 
         // Insert expected migration document

--- a/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
+++ b/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
@@ -4,24 +4,24 @@ using MongoDB.Driver;
 
 namespace CSharp.Mongo.Migration.Test.Data;
 
-public class TestMigration1 : IAsyncMigration {
+public class TestMigration1 : IMigration {
     public string Name => "Migration 1";
     public string Version => "1993.10.05 migration1";
 
-    public async Task DownAsync(IMongoDatabase database) {
+    public void Down(IMongoDatabase database) {
         var collection = database.GetCollection<TestDocumentV2>("Documents");
 
         var update = Builders<TestDocumentV2>.Update.Rename(d => d.FullName, nameof(TestDocumentV1.Name));
 
-        await collection.UpdateManyAsync(_ => true, update);
+        collection.UpdateMany(_ => true, update);
     }
 
-    public async Task UpAsync(IMongoDatabase database) {
+    public void Up(IMongoDatabase database) {
         var collection = database.GetCollection<TestDocumentV1>("Documents");
 
         var update = Builders<TestDocumentV1>.Update.Rename(d => d.Name, nameof(TestDocumentV2.FullName));
 
-        await collection.UpdateManyAsync(_ => true, update);
+        collection.UpdateMany(_ => true, update);
     }
 }
 

--- a/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
+++ b/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
@@ -109,7 +109,7 @@ public class MigrationRunner : IMigrationRunner {
         IEnumerable<IOrderedMigration> orderedMigrations = migrations.OfType<IOrderedMigration>();
         IEnumerable<IMigrationBase> basicMigrations = migrations.Where(m => m is not IOrderedMigration);
 
-        foreach (IAsyncMigration migration in basicMigrations) {
+        foreach (IMigrationBase migration in basicMigrations) {
             MigrationDocument document = await RunMigrationAsync(migration);
             steps.Add(document);
         }


### PR DESCRIPTION
Fixes errors thrown if a synchronous migration is run.

Updates tests to ensure this is caught in the future.