### PR TITLE
#27 - Ensure duplicate versioned migrations are not present during location

### DIFF
--- a/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
+++ b/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
@@ -54,6 +54,12 @@ public class MigrationRunner : IMigrationRunner {
             .GetAvailableMigrations(_migrationCollection)
             .Where(m => !m.Skip);
 
+        IEnumerable<IGrouping<string, IMigrationBase>> duplicateMigrations = migrations
+            .GroupBy(m => m.Version)
+            .Where(group => group.Count() > 1);
+        if (duplicateMigrations.Any())
+            throw new Exception($"Duplicate migration versions found: '{string.Join("', '", duplicateMigrations.Select(g => g.Key))}'");
+
         return await RunMigrationsAsync(migrations);
     }
 


### PR DESCRIPTION
Updated migration runner code and tests to implement the requirements stated:

- All migration locators should throw exceptions if duplicate versions are detected
- All duplicates should be detected, rather than just the first found, to avoid users fixing the first and then encountering the next
- Thrown exception should contain a message that describes all of the version strings that are duplicates

Now produces an Exception with a message like:
```
Duplicate migration versions found: '1993.10.07 migration2', '1993.10.09 migration3'
```