### PR TITLE
Feature/24: Wiki links now working as expected, both internal anchors, and external libraries

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,11 +26,9 @@ jobs:
       - name: Generate markdown
         run: |
           defaultdocumentation \
-            -o Documentation \
-            -a src/$projectName/bin/$configuration/$framework/$projectName.dll \
-            -n API \
-            -g Assembly \
-            --FileNameFactory Name
+            --AssemblyFilePath src/$projectName/bin/$configuration/$framework/$projectName.dll \
+            --ConfigurationFilePath ./docsconfig.json \
+            --OutputDirectoryPath Documentation \
       - name: Push to Wiki
         uses: SwiftDocOrg/github-wiki-publish-action@v1
         with:

--- a/.vscode/CSharp.Mongo.Migration.code-workspace
+++ b/.vscode/CSharp.Mongo.Migration.code-workspace
@@ -19,8 +19,8 @@
 	"extensions": {
 		"recommendations": [
 			"ms-dotnettools.csharp",
+			"ms-dotnettools.csdevkit",
 			"github.vscode-pull-request-github",
-			"jmrog.vscode-nuget-package-manager",
 			"ms-azure-devops.azure-pipelines",
 			"aaron-bond.better-comments",
 			"github.vscode-github-actions",

--- a/config/docs/mongodblinks.txt
+++ b/config/docs/mongodblinks.txt
@@ -1,0 +1,6 @@
+https://mongodb.github.io/mongo-csharp-driver/2.25.0/api/MongoDB.Bson/
+T:MongoDB.Bson.BsonObjectId|MongoDB.Bson.BsonObjectId.html
+T:MongoDB.Bson.ObjectId|MongoDB.Bson.ObjectId.-ctor.html
+https://mongodb.github.io/mongo-csharp-driver/2.25.0/api/MongoDB.Driver/
+T:MongoDB.Driver.IMongoCollection|MongoDB.Driver.IMongoCollection-1.html|MongoDB.Driver.IMongoCollection<TDocument>
+T:MongoDB.Driver.IMongoDatabase|MongoDB.Driver.IMongoDatabase.html|MongoDB.Driver.IMongoDatabase

--- a/docsconfig.json
+++ b/docsconfig.json
@@ -1,0 +1,9 @@
+{
+  "AssemblyPageName": "API",
+  "ExternLinksFilePaths": [
+    "./config/docs/mongodblinks.txt"
+  ],
+  "FileNameFactory": "Name",
+  "GeneratedPages": "Assembly",
+  "Markdown.RemoveFileExtensionFromUrl": true
+}


### PR DESCRIPTION
Closes [#24](https://github.com/JordanDChappell/CSharp.Mongo.Migration/issues/24)

## Problem
Internal library links in the wiki were incorrectly leading to raw markdown content and external library links (C# MongoDB) were incorrectly leading to missing Microsoft document pages.

## Solution
Update configuration for the `DefaultDocumentation` tool used to generate markdown for the wiki.

## Changes
- Prefer using a JSON configuration file for documentation generation
- Add `Markdown.RemoveFileExtensionFromUrl` configuration to remove `.md` extension from the generated internal links
- Add an 'Extern Links' file to configure C# MongoDB types to link to the source documentation pages

## Notes
The `docs.yml` workflow has been run manually on this branch and is working as intended: https://github.com/JordanDChappell/CSharp.Mongo.Migration/wiki/API