### PR TITLE
#30 - Add simple logging support to the MigrationRunner class using the Microsoft logging framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ When a migration has been applied a new document will be created in the target d
 
 **Note:** to override the default collection name, use a constructor that includes the `migrationCollectionName` parameter, or set the public `MigrationRunner.MigrationCollectionName` property.
 
+### Logging
+
+This library provides support for logging using [Microsoft.Extensions.Logging](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line).
+
+The `MigrationRunner` class writes information level logs that help to understand which migrations have been located and when they have successfully completed. In order to configure logging use the `RegisterLogger` function.
+
 ## Why Create Another Library?
 
 There are a number of other libraries for MongoDB designed to be used in C#. This library was written out of necessity to be used in a large development team with fairly sizeable database instances. There are some use cases that this library caters to that others do not:

--- a/src/CSharp.Mongo.Migration/Interfaces/IMigrationRunner.cs
+++ b/src/CSharp.Mongo.Migration/Interfaces/IMigrationRunner.cs
@@ -1,5 +1,7 @@
 ﻿using CSharp.Mongo.Migration.Models;
 
+using Microsoft.Extensions.Logging;
+
 namespace CSharp.Mongo.Migration.Interfaces;
 
 /// <summary>
@@ -12,6 +14,12 @@ public interface IMigrationRunner {
     /// <param name="locator">`IMigrationLocator` instance.</param>
     /// <returns>The current `IMigrationRunner` instance, `this`.</returns>
     public IMigrationRunner RegisterLocator(IMigrationLocator locator);
+    /// <summary>
+    /// Register an optional `ILogger` instance with the current runner instance.
+    /// </summary>
+    /// <param name="logger">`ILogger` instance.</param>
+    /// <returns>The current `IMigrationRunner` instance, `this`.</returns>
+    public IMigrationRunner RegisterLogger(ILogger logger);
     /// <summary>
     /// Run all available migrations.
     /// </summary>


### PR DESCRIPTION
Closes #30 

## Description
Enables simple log messages that inform consumers of the migrations that have been located and the order which they are run.

## Changes
- Update the `IMigrationRunner` contract to include a new `RegisterLogger` method
- Add a private `ILogger` instance to the `MigrationRunner` class, that defaults to the `NullLogger` type
- Implement the `RegisterLogger` method to override the default `NullLogger` instance
- Add some information logging events:
  -  A simple `Unable to locate any migrations to run, exiting application` message if no migrations need to be run
  - Log the found migrations, e.g. `Located 2 migration(s), preparing to run the following: '2024.01.01', '2024.02.02'`
  - Log completion of up / down methods, e.g. `Completed running migration with version: '2024.01.01'`

## Documentation
I've updated the project readme to include a section on logging.