### PR TITLE
25: Utilise a graph structure and simple topological sort to enforce order when running migrations

### DIFF
--- a/.vscode/CSharp.Mongo.Migration.code-workspace
+++ b/.vscode/CSharp.Mongo.Migration.code-workspace
@@ -21,7 +21,6 @@
 			"ms-dotnettools.csharp",
 			"ms-dotnettools.csdevkit",
 			"github.vscode-pull-request-github",
-			"ms-azure-devops.azure-pipelines",
 			"aaron-bond.better-comments",
 			"github.vscode-github-actions",
 		]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ If a migration requires or depends on another migration script, the `IOrderedMig
 
 **Note:** Circular dependency / valid graph checks are not implemented in the library at this time, be careful defining depencies to avoid issues.
 
+#### Ignoring Migrations
+
+If a migration is no longer required, you can remove the class from your application, or use the `[IgnoreMigration]` attribute on that class.
+
+For example:
+
+```
+[IgnoreMigration]
+public class MyMigration1 : IMigration { }
+```
+
 ### Restoring Migrations
 
 To revert or restore a migration run the `RevertAsync("version")` function on an instance of the `MigrationRunner` class

--- a/src/CSharp.Mongo.Migration.Test/CSharp.Mongo.Migration.Test.csproj
+++ b/src/CSharp.Mongo.Migration.Test/CSharp.Mongo.Migration.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>CSharp.Mongo.Migration.Test</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/CSharp.Mongo.Migration.Test/Core/Locators/AssemblyMigrationLocatorTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/Locators/AssemblyMigrationLocatorTests.cs
@@ -37,15 +37,10 @@ public class AssemblyMigrationLocatorTests : DatabaseTest, IDisposable {
 
     [Fact]
     public void GetMigrations_GivenAssemblyAndMigrationsInDatabase_ShouldReturnUnappliedMigrations() {
-        List<IMigrationBase> migrations = new() {
-            new TestMigration1(),
-            new TestMigration2(),
-            new TestMigration3(),
-        };
-
+        TestMigration1 migration = new();
         _migrationCollection.InsertOne(new() {
-            Name = migrations.First().Name,
-            Version = migrations.First().Version,
+            Name = migration.Name,
+            Version = migration.Version,
         });
 
         AssemblyMigrationLocator sut = new(Assembly.GetExecutingAssembly());

--- a/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
+++ b/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
@@ -97,3 +97,21 @@ public class TestMigration5 : IAsyncMigration, IOrderedMigration {
         return Task.CompletedTask;
     }
 }
+
+public class TestCyclicMigration1 : IOrderedMigration {
+    public IEnumerable<string> DependsOn => new List<string>() { "TestCyclicMigration2" };
+    public string Name => "TestCyclicMigration1";
+    public string Version => "TestCyclicMigration1";
+}
+
+public class TestCyclicMigration2 : IOrderedMigration {
+    public IEnumerable<string> DependsOn => new List<string>() { "TestCyclicMigration1" };
+    public string Name => "TestCyclicMigration2";
+    public string Version => "TestCyclicMigration2";
+}
+
+public class TestInvalidMigration : IOrderedMigration {
+    public IEnumerable<string> DependsOn => new List<string>() { "AMigrationThatDoesn'tExist" };
+    public string Name => "TestInvalidMigration";
+    public string Version => "TestInvalidMigration";
+}

--- a/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
+++ b/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
@@ -111,10 +111,3 @@ public class TestCyclicMigration2 : IOrderedMigration {
     public string Name => "TestCyclicMigration2";
     public string Version => "TestCyclicMigration2";
 }
-
-[IgnoreMigration]
-public class TestInvalidMigration : IOrderedMigration {
-    public IEnumerable<string> DependsOn => new List<string>() { "AMissingMigration" };
-    public string Name => "TestInvalidMigration";
-    public string Version => "TestInvalidMigration";
-}

--- a/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
+++ b/src/CSharp.Mongo.Migration.Test/Data/TestMigrations.cs
@@ -98,20 +98,23 @@ public class TestMigration5 : IAsyncMigration, IOrderedMigration {
     }
 }
 
+[IgnoreMigration]
 public class TestCyclicMigration1 : IOrderedMigration {
     public IEnumerable<string> DependsOn => new List<string>() { "TestCyclicMigration2" };
     public string Name => "TestCyclicMigration1";
     public string Version => "TestCyclicMigration1";
 }
 
+[IgnoreMigration]
 public class TestCyclicMigration2 : IOrderedMigration {
     public IEnumerable<string> DependsOn => new List<string>() { "TestCyclicMigration1" };
     public string Name => "TestCyclicMigration2";
     public string Version => "TestCyclicMigration2";
 }
 
+[IgnoreMigration]
 public class TestInvalidMigration : IOrderedMigration {
-    public IEnumerable<string> DependsOn => new List<string>() { "AMigrationThatDoesn'tExist" };
+    public IEnumerable<string> DependsOn => new List<string>() { "AMissingMigration" };
     public string Name => "TestInvalidMigration";
     public string Version => "TestInvalidMigration";
 }

--- a/src/CSharp.Mongo.Migration.Test/DataStructure/DirectedMigrationGraphTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/DataStructure/DirectedMigrationGraphTests.cs
@@ -8,13 +8,13 @@ namespace CSharp.Mongo.Migration.Test.DataStructure;
 public class DirectedMigrationGraphTests {
     [Fact]
     public void IsCyclic_GivenLinearDependencies_ShouldReturnFalse() {
-        List<IMigrationBase> migrations = new() {
+        List<IMigrationBase> migrations = [
             new TestMigration1(),
             new TestMigration2(),
             new TestMigration3(),
             new TestMigration4(),
             new TestMigration5(),
-        };
+        ];
 
         DirectedMigrationGraph graph = new(migrations);
 
@@ -34,28 +34,14 @@ public class DirectedMigrationGraphTests {
     }
 
     [Fact]
-    public void IsValid_GivenValidDependencies_ShouldReturnFalse() {
-        List<IMigrationBase> migrations = new() {
+    public void IsValid_GivenValidDependencies_ShouldReturnTrue() {
+        List<IMigrationBase> migrations = [
             new TestMigration1(),
             new TestMigration2(),
             new TestMigration3(),
             new TestMigration4(),
             new TestMigration5(),
-        };
-
-        DirectedMigrationGraph graph = new(migrations);
-
-        Assert.False(graph.IsValid());
-    }
-
-    [Fact]
-    public void IsValid_GivenInvalidDependencies_ShouldReturnTrue() {
-        List<IMigrationBase> migrations = new() {
-            new TestMigration1(),
-            new TestMigration4(),
-            new TestMigration5(),
-            new TestInvalidMigration(),
-        };
+        ];
 
         DirectedMigrationGraph graph = new(migrations);
 
@@ -63,13 +49,27 @@ public class DirectedMigrationGraphTests {
     }
 
     [Fact]
-    public void GetOrderedMigrations_GivenInvalidGraph_ShouldThrowException() {
-        List<IMigrationBase> migrations = new() {
+    public void IsValid_GivenInvalidDependencies_ShouldReturnFalse() {
+        List<IMigrationBase> migrations = [
             new TestMigration1(),
             new TestMigration4(),
             new TestMigration5(),
             new TestInvalidMigration(),
-        };
+        ];
+
+        DirectedMigrationGraph graph = new(migrations);
+
+        Assert.False(graph.IsValid());
+    }
+
+    [Fact]
+    public void GetOrderedMigrations_GivenInvalidGraph_ShouldThrowException() {
+        List<IMigrationBase> migrations = [
+            new TestMigration1(),
+            new TestMigration4(),
+            new TestMigration5(),
+            new TestInvalidMigration(),
+        ];
 
         DirectedMigrationGraph graph = new(migrations);
 
@@ -79,10 +79,10 @@ public class DirectedMigrationGraphTests {
 
     [Fact]
     public void GetOrderedMigrations_GivenCyclicGraph_ShouldThrowException() {
-        List<IMigrationBase> migrations = new() {
+        List<IMigrationBase> migrations = [
             new TestCyclicMigration1(),
             new TestCyclicMigration2(),
-        };
+        ];
 
         DirectedMigrationGraph graph = new(migrations);
 
@@ -92,23 +92,23 @@ public class DirectedMigrationGraphTests {
 
     [Fact]
     public void GetOrderedMigrations_GivenValidAcyclicGraph_ShouldReturnMigrations() {
-        List<IMigrationBase> migrations = new() {
+        List<IMigrationBase> migrations = [
+            new TestMigration5(),
+            new TestMigration4(),
             new TestMigration1(),
             new TestMigration2(),
             new TestMigration3(),
-            new TestMigration4(),
-            new TestMigration5(),
-        };
+        ];
 
         DirectedMigrationGraph graph = new(migrations);
 
         List<IMigrationBase> result = graph.GetOrderedMigrations();
 
         Assert.Equal(migrations.Count, result.Count);
-        Assert.Equal(0, result.FindIndex(m => m.Version == migrations[0].Version));
-        Assert.Equal(1, result.FindIndex(m => m.Version == migrations[3].Version));
-        Assert.Equal(2, result.FindIndex(m => m.Version == migrations[4].Version));
-        Assert.Equal(3, result.FindIndex(m => m.Version == migrations[1].Version));
-        Assert.Equal(4, result.FindIndex(m => m.Version == migrations[2].Version));
+        Assert.Equal(0, result.FindIndex(m => m.Version == "1993.10.05 migration1"));
+        Assert.Equal(1, result.FindIndex(m => m.Version == "1993.10.07 migration2"));
+        Assert.Equal(2, result.FindIndex(m => m.Version == "1993.10.09 migration3"));
+        Assert.Equal(3, result.FindIndex(m => m.Version == "2024.01.01 migration4"));
+        Assert.Equal(4, result.FindIndex(m => m.Version == "2024.02.01 migration5"));
     }
 }

--- a/src/CSharp.Mongo.Migration.Test/DataStructure/DirectedMigrationGraphTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/DataStructure/DirectedMigrationGraphTests.cs
@@ -23,58 +23,14 @@ public class DirectedMigrationGraphTests {
 
     [Fact]
     public void IsCyclic_GivenCyclicalDependencies_ShouldReturnTrue() {
-        List<IMigrationBase> migrations = new() {
+        List<IMigrationBase> migrations = [
             new TestCyclicMigration1(),
             new TestCyclicMigration2(),
-        };
+        ];
 
         DirectedMigrationGraph graph = new(migrations);
 
         Assert.True(graph.IsCyclic());
-    }
-
-    [Fact]
-    public void IsValid_GivenValidDependencies_ShouldReturnTrue() {
-        List<IMigrationBase> migrations = [
-            new TestMigration1(),
-            new TestMigration2(),
-            new TestMigration3(),
-            new TestMigration4(),
-            new TestMigration5(),
-        ];
-
-        DirectedMigrationGraph graph = new(migrations);
-
-        Assert.True(graph.IsValid());
-    }
-
-    [Fact]
-    public void IsValid_GivenInvalidDependencies_ShouldReturnFalse() {
-        List<IMigrationBase> migrations = [
-            new TestMigration1(),
-            new TestMigration4(),
-            new TestMigration5(),
-            new TestInvalidMigration(),
-        ];
-
-        DirectedMigrationGraph graph = new(migrations);
-
-        Assert.False(graph.IsValid());
-    }
-
-    [Fact]
-    public void GetOrderedMigrations_GivenInvalidGraph_ShouldThrowException() {
-        List<IMigrationBase> migrations = [
-            new TestMigration1(),
-            new TestMigration4(),
-            new TestMigration5(),
-            new TestInvalidMigration(),
-        ];
-
-        DirectedMigrationGraph graph = new(migrations);
-
-        var exception = Assert.Throws<Exception>(graph.GetOrderedMigrations);
-        Assert.Contains("Missing migration dependency", exception.Message);
     }
 
     [Fact]

--- a/src/CSharp.Mongo.Migration.Test/DataStructure/DirectedMigrationGraphTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/DataStructure/DirectedMigrationGraphTests.cs
@@ -1,0 +1,114 @@
+﻿
+using CSharp.Mongo.Migration.DataStructure;
+using CSharp.Mongo.Migration.Interfaces;
+using CSharp.Mongo.Migration.Test.Data;
+
+namespace CSharp.Mongo.Migration.Test.DataStructure;
+
+public class DirectedMigrationGraphTests {
+    [Fact]
+    public void IsCyclic_GivenLinearDependencies_ShouldReturnFalse() {
+        List<IMigrationBase> migrations = new() {
+            new TestMigration1(),
+            new TestMigration2(),
+            new TestMigration3(),
+            new TestMigration4(),
+            new TestMigration5(),
+        };
+
+        DirectedMigrationGraph graph = new(migrations);
+
+        Assert.False(graph.IsCyclic());
+    }
+
+    [Fact]
+    public void IsCyclic_GivenCyclicalDependencies_ShouldReturnTrue() {
+        List<IMigrationBase> migrations = new() {
+            new TestCyclicMigration1(),
+            new TestCyclicMigration2(),
+        };
+
+        DirectedMigrationGraph graph = new(migrations);
+
+        Assert.True(graph.IsCyclic());
+    }
+
+    [Fact]
+    public void IsValid_GivenValidDependencies_ShouldReturnFalse() {
+        List<IMigrationBase> migrations = new() {
+            new TestMigration1(),
+            new TestMigration2(),
+            new TestMigration3(),
+            new TestMigration4(),
+            new TestMigration5(),
+        };
+
+        DirectedMigrationGraph graph = new(migrations);
+
+        Assert.False(graph.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_GivenInvalidDependencies_ShouldReturnTrue() {
+        List<IMigrationBase> migrations = new() {
+            new TestMigration1(),
+            new TestMigration4(),
+            new TestMigration5(),
+            new TestInvalidMigration(),
+        };
+
+        DirectedMigrationGraph graph = new(migrations);
+
+        Assert.True(graph.IsValid());
+    }
+
+    [Fact]
+    public void GetOrderedMigrations_GivenInvalidGraph_ShouldThrowException() {
+        List<IMigrationBase> migrations = new() {
+            new TestMigration1(),
+            new TestMigration4(),
+            new TestMigration5(),
+            new TestInvalidMigration(),
+        };
+
+        DirectedMigrationGraph graph = new(migrations);
+
+        var exception = Assert.Throws<Exception>(graph.GetOrderedMigrations);
+        Assert.Contains("Missing migration dependency", exception.Message);
+    }
+
+    [Fact]
+    public void GetOrderedMigrations_GivenCyclicGraph_ShouldThrowException() {
+        List<IMigrationBase> migrations = new() {
+            new TestCyclicMigration1(),
+            new TestCyclicMigration2(),
+        };
+
+        DirectedMigrationGraph graph = new(migrations);
+
+        var exception = Assert.Throws<Exception>(graph.GetOrderedMigrations);
+        Assert.Contains("Circular migration dependencies detected", exception.Message);
+    }
+
+    [Fact]
+    public void GetOrderedMigrations_GivenValidAcyclicGraph_ShouldReturnMigrations() {
+        List<IMigrationBase> migrations = new() {
+            new TestMigration1(),
+            new TestMigration2(),
+            new TestMigration3(),
+            new TestMigration4(),
+            new TestMigration5(),
+        };
+
+        DirectedMigrationGraph graph = new(migrations);
+
+        List<IMigrationBase> result = graph.GetOrderedMigrations();
+
+        Assert.Equal(migrations.Count, result.Count);
+        Assert.Equal(0, result.FindIndex(m => m.Version == migrations[0].Version));
+        Assert.Equal(1, result.FindIndex(m => m.Version == migrations[3].Version));
+        Assert.Equal(2, result.FindIndex(m => m.Version == migrations[4].Version));
+        Assert.Equal(3, result.FindIndex(m => m.Version == migrations[1].Version));
+        Assert.Equal(4, result.FindIndex(m => m.Version == migrations[2].Version));
+    }
+}

--- a/src/CSharp.Mongo.Migration/Attributes/IgnoreMigrationAttribute.cs
+++ b/src/CSharp.Mongo.Migration/Attributes/IgnoreMigrationAttribute.cs
@@ -1,0 +1,5 @@
+/// <summary>
+/// Tells the `AssemblyMigrationLocator` class to ignore this migration.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class IgnoreMigrationAttribute : Attribute { }

--- a/src/CSharp.Mongo.Migration/CSharp.Mongo.Migration.csproj
+++ b/src/CSharp.Mongo.Migration/CSharp.Mongo.Migration.csproj
@@ -29,4 +29,5 @@
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="" />
   </ItemGroup>
+  
 </Project>

--- a/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
+++ b/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
@@ -33,6 +33,11 @@ public class AssemblyMigrationLocator : IMigrationLocator {
 
     private bool IsMigration(Type type) => _migrationType.IsAssignableFrom(type) && type.IsClass && !type.IsAbstract;
 
-    private IEnumerable<IMigrationBase> GetMigrationsFromAssembly() =>
-        _assembly.GetTypes().Where(IsMigration).Select(t => (IMigrationBase)Activator.CreateInstance(t));
+    private bool HasIgnoreMigrationAttribute(Type type) => type.IsDefined(typeof(IgnoreMigrationAttribute), false);
+
+    private IEnumerable<IMigrationBase> GetMigrationsFromAssembly() => _assembly
+        .GetTypes()
+        .Where(IsMigration)
+        .Where(t => !HasIgnoreMigrationAttribute(t))
+        .Select(t => (IMigrationBase)Activator.CreateInstance(t));
 }

--- a/src/CSharp.Mongo.Migration/DataStructure/DirectedMigrationGraph.cs
+++ b/src/CSharp.Mongo.Migration/DataStructure/DirectedMigrationGraph.cs
@@ -1,0 +1,152 @@
+﻿using CSharp.Mongo.Migration.Interfaces;
+
+namespace CSharp.Mongo.Migration.DataStructure;
+
+/// <summary>
+/// A directed graph used to contain and act upon ordered migrations.
+/// </summary>
+public class DirectedMigrationGraph {
+    /// <summary>
+    /// A reference to all migrations, not just those that exist in the dependency graph.
+    /// </summary>
+    private readonly IEnumerable<IMigrationBase> _allMigrations;
+    /// <summary>
+    /// Migrations with their dependencies as graph nodes.
+    /// </summary>
+    private readonly Dictionary<string, List<string>> _nodes = [];
+
+    public DirectedMigrationGraph(IEnumerable<IMigrationBase> migrations) {
+        _allMigrations = migrations;
+        BuildGraph();
+    }
+
+    /// <summary>
+    /// Build the `_nodes` dictionary from the collection of migrations.
+    /// </summary>
+    private void BuildGraph() {
+        foreach (IMigrationBase migration in _allMigrations) {
+            if (migration is IOrderedMigration orderedMigration)
+                _nodes.Add(orderedMigration.Version, orderedMigration.DependsOn.ToList());
+        }
+    }
+
+    /// <summary>
+    /// Apply a topological sort to the graph, and return migrations that have / are dependencies in the sorted order.
+    /// </summary>
+    /// <returns>Migrations, in a reasonable order according to dependencies.</returns>
+    private List<IMigrationBase> TopologicalSortMigrations() {
+        List<string> topologicalOrdering = [];
+
+        // Construct a mapping of nodes to their indegrees (number of edges into each node)
+        Dictionary<string, int> indegrees = _nodes.Keys.ToDictionary(key => key, _ => 0);
+        foreach (string node in _nodes.Keys) {
+            foreach (string dependency in _nodes[node]) {
+                if (indegrees.TryGetValue(dependency, out int value))
+                    indegrees[node] = value + 1;
+            }
+        }
+
+        // Start by adding nodes with indegree 0
+        // As long as there are nodes with no incoming edges, keep adding them to the sorted collection
+        Queue<string> nodesWithNoIncomingEdges = new(indegrees.Where(kvp => kvp.Value == 0).Select(kvp => kvp.Key));
+        while (nodesWithNoIncomingEdges.Count > 0) {
+            // Add one of those nodes to the ordering
+            string node = nodesWithNoIncomingEdges.Dequeue();
+            topologicalOrdering.Add(node);
+
+            // Decremenet the indegree of that node's dependencies
+            foreach (string dependency in _nodes[node]) {
+                indegrees[dependency] -= 1;
+                if (indegrees[dependency] == 0)
+                    nodesWithNoIncomingEdges.Enqueue(dependency);
+            }
+        }
+
+        return _allMigrations
+            .Where(m => topologicalOrdering.Contains(m.Version))
+            .OrderBy(m => topologicalOrdering.IndexOf(m.Version))
+            .ToList();
+    }
+
+    /// <summary>
+    /// A recursive helper function used to find cycles for a particular node in the graph.
+    /// </summary>
+    /// <param name="node">Node / migration version.</param>
+    /// <param name="visitedNodes">A collection of nodes that have already been visited.</param>
+    /// <param name="recursionStack">A collection of nodes that are candidates for a cycle.</param>
+    /// <returns>True if a cycle is found containing the provided node, else false.</returns>
+    private bool IsCyclicRecursiveHelper(string node, List<string> visitedNodes, List<string> recursionStack) {
+        if (recursionStack.Contains(node))
+            return true;
+
+        if (visitedNodes.Contains(node))
+            return false;
+
+        visitedNodes.Add(node);
+        recursionStack.Add(node);
+        List<string> dependencies = _nodes[node];
+
+        foreach (string version in dependencies) {
+            IMigrationBase dependency = _allMigrations.First(m => m.Version == version);
+            if (
+                dependency is IOrderedMigration orderedDependency &&
+                IsCyclicRecursiveHelper(orderedDependency.Version, visitedNodes, recursionStack)
+            )
+                return true;
+        }
+
+        recursionStack.Remove(node);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determine if any cycles exist within the graph.
+    /// </summary>
+    /// <returns>True if the graph contains a cycle, else false.</returns>
+    public bool IsCyclic() {
+        List<string> visitedNodes = [];
+        List<string> recursionStack = [];
+
+        foreach (string version in _nodes.Keys)
+            if (IsCyclicRecursiveHelper(version, visitedNodes, recursionStack))
+                return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Ensure that all dependencies have been located for each node in the graph.
+    /// </summary>
+    /// <returns>True if the graph is valid, else false.</returns>
+    public bool IsValid() {
+        foreach (string version in _nodes.Keys) {
+            List<string> node = _nodes[version];
+
+            if (_allMigrations.First(m => m.Version == version) is not IOrderedMigration orderedMigration)
+                return false;
+
+            if (node.Count != orderedMigration.DependsOn.Count())
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determine an order of nodes in the graph and return an ordered collection of migrations.
+    /// </summary>
+    /// <returns>An ordered collection of migrations.</returns>
+    public List<IMigrationBase> GetOrderedMigrations() {
+        if (!IsValid())
+            throw new Exception("Missing migration dependency, unable to determine order");
+
+        if (IsCyclic())
+            throw new Exception("Circular migration dependencies detected, unable to determine order");
+
+        // Ordered migrations first, then add the left overs
+        List<IMigrationBase> migrations = TopologicalSortMigrations();
+        migrations.AddRange(_allMigrations.Where(m => !migrations.Any(mi => mi.Version == m.Version)));
+        return migrations;
+    }
+}


### PR DESCRIPTION
## Description
Rather than lazily loop through all ordered migrations checking if their dependencies are met, we now have a directed graph structure for migrations with methods to assert valid dependency chains and retrieve an ordering for migrations.

## Changes
- Implement an `IgnoreMigration` attribute class which tells the assembly locator to ignore migrations
  - This was required after adding three new migrations with invalid cyclical and unmet dependencies as they were being located by other tests and breaking
-  Implement `DirectedMigrationGraph` class which is constructed using a collection of migrations, and has a method to retrieve the migrations in a sane order
  - This class also checks for cycles in migrations, to avoid circular dependencies, and ensures that no migration has a dependency which cannot be met 
- Utilise the `DirectedMigrationGraph` class within the `MigrationRunner` in place of the existing ordered migration logic

### Out of scope
- Remove recommended vscode extension which is not required
- Update the `CSharp.Mongo.Migration.Test` project to .NET 8

## Documentation
The README.md file includes information about the `IgnoreMigration` attribute