### PR TITLE
#33 introduce binding to MongoDB.Driver version 3.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="EphemeralMongo7" Version="1.1.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.24.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>

--- a/src/CSharp.Mongo.Migration.Test/Infrastructure/DatabaseTestFixture.cs
+++ b/src/CSharp.Mongo.Migration.Test/Infrastructure/DatabaseTestFixture.cs
@@ -6,7 +6,7 @@ using MongoDB.Driver;
 
 namespace CSharp.Mongo.Migration.Test.Infrastructure;
 
-public class DatabaseTestFixture : IDisposable {
+public class DatabaseTestFixture {
     private readonly IMongoRunner _mongoDbRunner;
 
     public IMongoDatabase Database { get; set; }
@@ -16,9 +16,5 @@ public class DatabaseTestFixture : IDisposable {
         _mongoDbRunner = MongoRunner.Run();
         ConnectionString = $"{_mongoDbRunner.ConnectionString}/test";
         Database = DatabaseConnectionFactory.GetDatabase(ConnectionString);
-    }
-
-    public void Dispose() {
-        _mongoDbRunner.Dispose();
     }
 }


### PR DESCRIPTION
This is not a backwards compatible change as the `MongoDB.Driver` library introduced Strong-Named Assemblies in `2.27.0`, hence a new major version of this library.

Using `MongoDB.Driver` version `3.0.0` is required to be in lock step with some other MongoDB related libraries.