### PR TITLE
devops/use-dotnet-9: Uplift test project + action runners to .NET 9, apply collection expression suggestions across the solution

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,10 +14,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET 8.x
+      - name: Setup .NET 9.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,10 +14,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET 7.x
+      - name: Setup .NET 8.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '7.x'
+          dotnet-version: '8.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup .NET 8.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET 7.x
+      - name: Setup .NET 8.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '7.x'
+          dotnet-version: '8.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,10 +15,10 @@ jobs:
       projectName: CSharp.Mongo.Migration
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET 7.x
+      - name: Setup .NET 8.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '7.x'
+          dotnet-version: '8.x'
       - name: Install tools
         run: dotnet tool install DefaultDocumentation.Console -g
       - name: Build solution

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,10 +15,10 @@ jobs:
       projectName: CSharp.Mongo.Migration
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET 8.x
+      - name: Setup .NET 9.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
       - name: Install tools
         run: dotnet tool install DefaultDocumentation.Console -g
       - name: Build solution

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,10 +15,10 @@ jobs:
         testResultsDirectory: TestResults
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET 8.x
+      - name: Setup .NET 9.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,10 +15,10 @@ jobs:
         testResultsDirectory: TestResults
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET 7.x
+      - name: Setup .NET 8.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '7.x'
+          dotnet-version: '8.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Test

--- a/.globalconfig
+++ b/.globalconfig
@@ -1,3 +1,7 @@
 is_global = true
 
+#Missing XML comment for publicly visible type or member 'Type_or_Member'
 dotnet_diagnostic.CS1591.severity = none
+
+#Use collection initializers or expressions (IDE0028)
+dotnet_diagnostic.IDE0028.severity = warning

--- a/src/CSharp.Mongo.Migration.Test/CSharp.Mongo.Migration.Test.csproj
+++ b/src/CSharp.Mongo.Migration.Test/CSharp.Mongo.Migration.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>CSharp.Mongo.Migration.Test</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/CSharp.Mongo.Migration.Test/Core/Locators/ProvidedMigrationLocatorTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Core/Locators/ProvidedMigrationLocatorTests.cs
@@ -17,11 +17,11 @@ public class ProvidedMigrationLocatorTests : DatabaseTest, IDisposable {
 
     [Fact]
     public void GetMigrations_GivenNoMigrationsInDatabase_ShouldReturnAllMigrations() {
-        List<IMigrationBase> migrations = new() {
+        List<IMigrationBase> migrations = [
             new TestMigration1(),
             new TestMigration2(),
             new TestMigration3(),
-        };
+        ];
 
         ProvidedMigrationLocator sut = new(migrations);
 
@@ -32,11 +32,11 @@ public class ProvidedMigrationLocatorTests : DatabaseTest, IDisposable {
 
     [Fact]
     public void GetMigrations_GivenMigrationsInDatabase_ShouldReturnUnappliedMigrations() {
-        List<IMigrationBase> migrations = new() {
+        List<IMigrationBase> migrations = [
             new TestMigration1(),
             new TestMigration2(),
             new TestMigration3(),
-        };
+        ];
 
         _migrationCollection.InsertOne(new() {
             Name = migrations.First().Name,

--- a/src/CSharp.Mongo.Migration.Test/Helpers/MigrationRunnerHelperTests.cs
+++ b/src/CSharp.Mongo.Migration.Test/Helpers/MigrationRunnerHelperTests.cs
@@ -8,18 +8,18 @@ namespace CSharp.Mongo.Migration.Test.Helpers;
 public class MigrationRunnerHelperTests {
     [Fact]
     public void FindMigrationsWhereDependenciesAreMet_GivenAllDependenciesMet_ShouldReturnAll() {
-        List<IOrderedMigration> orderedMigrations = new() {
+        List<IOrderedMigration> orderedMigrations = [
             new TestMigration4(),
             new TestMigration5(),
-        };
-        List<MigrationDocument> migrationDocuments = new() {
+        ];
+        List<MigrationDocument> migrationDocuments = [
             new MigrationDocument() {
                 Version = "1993.10.05 migration1",
             },
             new MigrationDocument() {
                 Version = "2024.01.01 migration4",
             },
-        };
+        ];
 
         var result = MigrationRunnerHelper.FindMigrationsWhereDependenciesAreMet(orderedMigrations, migrationDocuments);
 
@@ -28,15 +28,15 @@ public class MigrationRunnerHelperTests {
 
     [Fact]
     public void FindMigrationsWhereDependenciesAreMet_GivenNotAllDependenciesMet_ShouldReturnExpectedResult() {
-        List<IOrderedMigration> orderedMigrations = new() {
+        List<IOrderedMigration> orderedMigrations = [
             new TestMigration4(),
             new TestMigration5(),
-        };
-        List<MigrationDocument> migrationDocuments = new() {
+        ];
+        List<MigrationDocument> migrationDocuments = [
             new MigrationDocument() {
                 Version = "1993.10.05 migration1",
             },
-        };
+        ];
 
         var result = MigrationRunnerHelper.FindMigrationsWhereDependenciesAreMet(orderedMigrations, migrationDocuments);
 
@@ -45,15 +45,15 @@ public class MigrationRunnerHelperTests {
 
     [Fact]
     public void AnyMigrationsLeftToRun_GivenNotAllDocumentsExist_ShouldReturnTrue() {
-        List<IOrderedMigration> orderedMigrations = new() {
+        List<IOrderedMigration> orderedMigrations = [
             new TestMigration4(),
             new TestMigration5(),
-        };
-        List<MigrationDocument> migrationDocuments = new() {
+        ];
+        List<MigrationDocument> migrationDocuments = [
             new MigrationDocument() {
                 Version = "2024.01.01 migration4",
             },
-        };
+        ];
 
         var result = MigrationRunnerHelper.AnyMigrationsLeftToRun(orderedMigrations, migrationDocuments);
 
@@ -62,18 +62,18 @@ public class MigrationRunnerHelperTests {
 
     [Fact]
     public void AnyMigrationsLeftToRun_GivenAllDocumentsExist_ShouldReturnFalse() {
-        List<IOrderedMigration> orderedMigrations = new() {
+        List<IOrderedMigration> orderedMigrations = [
             new TestMigration4(),
             new TestMigration5(),
-        };
-        List<MigrationDocument> migrationDocuments = new() {
+        ];
+        List<MigrationDocument> migrationDocuments = [
             new MigrationDocument() {
                 Version = "2024.01.01 migration4",
             },
             new MigrationDocument() {
                 Version = "2024.02.01 migration5",
             },
-        };
+        ];
 
         var result = MigrationRunnerHelper.AnyMigrationsLeftToRun(orderedMigrations, migrationDocuments);
 

--- a/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
+++ b/src/CSharp.Mongo.Migration/Core/MigrationRunner.cs
@@ -119,7 +119,7 @@ public class MigrationRunner : IMigrationRunner {
         _logger.LogInformation("Completed reverting migration with version: '{version}'", migration.Version);
 
         return new() {
-            Steps = new List<MigrationDocument>() { document },
+            Steps = [document],
         };
     }
 
@@ -139,7 +139,7 @@ public class MigrationRunner : IMigrationRunner {
     }
 
     private async Task<MigrationResult> RunMigrationsAsync(IEnumerable<IMigrationBase> migrations) {
-        List<MigrationDocument> steps = new();
+        List<MigrationDocument> steps = [];
         DirectedMigrationGraph graph = new(migrations);
         IEnumerable<IMigrationBase> orderedMigrations = graph.GetOrderedMigrations();
 

--- a/src/CSharp.Mongo.Migration/Infrastructure/DatabaseConnectionFactory.cs
+++ b/src/CSharp.Mongo.Migration/Infrastructure/DatabaseConnectionFactory.cs
@@ -6,7 +6,7 @@ namespace CSharp.Mongo.Migration.Infrastructure;
 /// Manage connections to MongoDB.
 /// </summary>
 public static class DatabaseConnectionFactory {
-    private static readonly Dictionary<string, IMongoDatabase> _databases = new();
+    private static readonly Dictionary<string, IMongoDatabase> _databases = [];
 
     /// <summary>
     /// Retrieve an instance of the MongoDB driver `IMongoDatabase` class with the provided connection.


### PR DESCRIPTION
## Description
Update .NET version to latest where appropriate in test projects and pipelines.

## Changes
- Update the version pattern used by the `setup-dotnet` task in GitHub actions workflows
- Update the `CSharp.Mongo.Migration.Test` project framework to `net9.0`
- Enforce IDE0028 (Use collection initializers or expressions) as a warning
- Apply code suggestions for collection expressions where appropriate across the entire `CSharp.Mongo.Migration.sln` solution