### PR TITLE
bugfix/issue-38: Fixes an issue that caused an exception when generating a graph of migrations to run

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="AutoMoqCore" Version="2.1.0" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="EphemeralMongo7" Version="1.1.3" />
+    <PackageVersion Include="EphemeralMongo7" Version="2.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />

--- a/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
+++ b/src/CSharp.Mongo.Migration/Core/Locators/AssemblyMigrationLocator.cs
@@ -23,6 +23,8 @@ public class AssemblyMigrationLocator : IMigrationLocator {
         _assembly = Assembly.LoadFrom(assemblyFile);
     }
 
+    public IEnumerable<IMigrationBase> GetAllMigrations() => GetMigrationsFromAssembly();
+
     public IEnumerable<IMigrationBase> GetAvailableMigrations(IMongoCollection<MigrationDocument> collection) {
         IEnumerable<IMigrationBase> migrations = GetMigrationsFromAssembly();
         return MigrationLocatorHelper.FilterCompletedMigrations(collection, migrations);

--- a/src/CSharp.Mongo.Migration/Core/Locators/ProvidedMigrationLocator.cs
+++ b/src/CSharp.Mongo.Migration/Core/Locators/ProvidedMigrationLocator.cs
@@ -16,6 +16,8 @@ public class ProvidedMigrationLocator : IMigrationLocator {
         _migrations = migrations;
     }
 
+    public IEnumerable<IMigrationBase> GetAllMigrations() => _migrations;
+
     public IEnumerable<IMigrationBase> GetAvailableMigrations(IMongoCollection<MigrationDocument> collection) =>
         MigrationLocatorHelper.FilterCompletedMigrations(collection, _migrations);
 

--- a/src/CSharp.Mongo.Migration/Interfaces/IMigrationLocator.cs
+++ b/src/CSharp.Mongo.Migration/Interfaces/IMigrationLocator.cs
@@ -9,6 +9,11 @@ namespace CSharp.Mongo.Migration.Interfaces;
 /// </summary>
 public interface IMigrationLocator {
     /// <summary>
+    /// Retrieve a collection of all `IMigrationBase` instances that can be located.
+    /// </summary>
+    /// <returns>Collection of `IMigrationBase` instances/</returns>
+    public IEnumerable<IMigrationBase> GetAllMigrations();
+    /// <summary>
     /// Retrieve a collection of `IMigrationBase` instances that have not been run.
     /// </summary>
     /// <param name="collection">Collection of `MigrationDocument` database entries or migrations that have been 


### PR DESCRIPTION
## Problem
If a migration is presented that depends on another migration that is already run / recorded, then an exception is thrown from the graph generator as it builds it's dependency graph from only migrations that have not yet run.

## Solution
Add a new method contract to the `IMigrationLocator` interface (and implement it where required) that retrieves all migrations, so that the graph can be built from the full set.

## Changes
- New `GetAllMigrations` method on `IMigrationLocator`
  - Implemented in `AssemblyMigrationLocator` and `ProvidedMigrationLocator`
- Update the `MigrationRunner` class to build a dependency graph from all migrations, and then run those that need to be run alone

## Tests
- A new integration test has been implemented that was used to debug and ensure this fix worked

Closes #38 