### PR TITLE
feature/mongo-driver-3.4.0: Bumping to latest driver version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Setup .NET 9.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '9.x'
+          dotnet-version: | 
+            6.x
+            9.x
       - name: Install tools
         run: dotnet tool install DefaultDocumentation.Console -g
       - name: Build solution

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="EphemeralMongo7" Version="2.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>


### PR DESCRIPTION
## Description
In the essence of keeping this library up to date, I'll try to raise a new PR into `main` for each new `MongoDB.Driver` version released. This merge commit will also form the `3.4.0` release of this package (keeping in lock-step with `MongoDB.Driver` project.

## Changes
- Update `MongoDB.Driver` package version to latest (3.4.0)

## Tests
- I ran the test suite locally, all passing
