### PR TITLE
devops/package-versions: Update package versions to latest where appropriate + set up dependabot.yml file for automatic update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: 'nuget'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      # Single PR per MongoDB.Driver update
+      production-dependencies:
+        dependency-type: 'production'
+        patterns:
+          - 'MongoDB.Driver'
+      # Group all other minor / patch updates into a single PR at time of run
+      development-dependencies:
+        dependency-type: 'development'
+        exclude-patterns:
+          - 'MongoDB.Driver'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,9 +6,9 @@
     <PackageVersion Include="AutoMoqCore" Version="2.1.0" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="EphemeralMongo7" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.4.2" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bumping all package versions to latest, all of these were minor or patch versions, with the exception of the `xunit.runner.visualstudio` development dependency.

I've also created a new `dependabot.yml` file which is set up to:
- Trigger a dependency version check weekly
- Consider updates for dependencies in two explicit groupings (keeping changes in these groups within a single PR):
  - `MongoDB.Driver` = production dependency
  - All other packages minor and patch updates = development dependency
  - All other packages major updates = implicit ungrouped  PRs