### PR TITLE
devops/trusted-publishing: Update deploy pipeline to use trusted publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,8 @@
 name: cd
 
+permissions:
+  id-token: write
+
 on:
   release:
     types: [published]
@@ -12,6 +15,7 @@ jobs:
       configuration: Release
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET 9.x
@@ -24,5 +28,10 @@ jobs:
         run: dotnet build --configuration $configuration /p:Version=${{github.event.release.name}} $projectPath
       - name: Pack
         run: dotnet pack --configuration $configuration --no-build /p:PackageVersion=${{github.event.release.name}} $projectPath --output .
+      - name: NuGet Login
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{secrets.NUGET_USER}}
       - name: Push
-        run: dotnet nuget push "*.nupkg" --api-key ${{secrets.NUGET_KEY}} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "*.nupkg" --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See the [Wiki](https://github.com/JordanDChappell/CSharp.Mongo.Migration/wiki) f
 
 ## Status
 ![ci](https://github.com/JordanDChappell/CSharp.Mongo.Migration/actions/workflows/ci.yml/badge.svg?branch=main)
-![cd](https://github.com/JordanDChappell/CSharp.Mongo.Migration/actions/workflows/cd.yml/badge.svg?branch=main)
+![cd](https://github.com/JordanDChappell/CSharp.Mongo.Migration/actions/workflows/cd.yml/badge.svg)
 ![pr](https://github.com/JordanDChappell/CSharp.Mongo.Migration/actions/workflows/pr.yml/badge.svg?branch=main)
 
 ## Usage
@@ -56,9 +56,7 @@ An optional `bool Skip()` method can be defined that can be used to conditionall
 
 #### Explicit Order
 
-If a migration requires or depends on another migration script, the `IOrderedMigration` interface can be used and it's `DependsOn` property implemented to provide a version dependencies between migrations. Migrations need to implement one of the `IMigration` or `IAsyncMigration` interfaces along with the `IOrderedMigration` interface to be loaded and run.
-
-**Note:** Circular dependency / valid graph checks are not implemented in the library at this time, be careful defining depencies to avoid issues.
+If a migration requires or depends on another migration script, the `IOrderedMigration` interface can be used and it's `DependsOn` property implemented to provide version dependencies between migrations. Migrations need to implement one of the `IMigration` or `IAsyncMigration` interfaces along with the `IOrderedMigration` interface to be loaded and run.
 
 #### Ignoring Migrations
 


### PR DESCRIPTION
## Description
NuGet / GitHub now support short-lived tokens for publishing packages: https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/nuget-org/trusted-publishing.md

This PR updates the `cd.yml` workflow file to implement the simple steps required to utilise this new security mechanism..

## Changes
- Update `cd.yml` file to include the required permissions and new login step to generate a short lived key for NuGet
- Tweak `README.md` file to fix the `cd.yml` badge (doesn't run on `main`) and remove an unnecessary note about circular dependency / graph checking (that we have)

## Test considerations
I haven't tested this on this repo, I'd rather not set up a non-prod package for that purpose, hopefully the copy / paste I've completed is okay.